### PR TITLE
Update helm repository location for "stable"

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ helm repo add bitnami https://charts.bitnami.com/bitnami
 ```shell
 cd infrastructure
 helm dep up
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add stable https://charts.helm.sh/stable
 cd ..
 ```
 


### PR DESCRIPTION
As of this blog post the location of the stable repository has moved:

  https://helm.sh/blog/new-location-stable-incubator-charts/

Using the old location will result in a 403.