### PR TITLE
Volumemounts in Archive-Service

### DIFF
--- a/yuuvis/templates/archiveservice.yaml
+++ b/yuuvis/templates/archiveservice.yaml
@@ -58,8 +58,16 @@ spec:
               key: CONFIGSERVICEURL
         ports:
         - containerPort: {{.Values.yuuvis.services.archive.port}}
+        {{- if .Values.yuuvis.services.archive.volumeMounts }}
+        volumeMounts:
+{{ tpl .Values.yuuvis.services.archive.volumeMounts . | indent 8 }}
+        {{- end }}
       restartPolicy: Always
       automountServiceAccountToken: false
       imagePullSecrets:
       - name: yuuvisorg
+      {{- if .Values.yuuvis.services.archive.volumes }}
+      volumes:
+{{ tpl .Values.yuuvis.services.archive.volumes . | indent 6 }}
+      {{- end}}
 {{- end}}


### PR DESCRIPTION
Add a configurable volume/volumemount to the `archiveservice`, so that it can be populated with mounts to storage solutions.
Inspired by the definition of the deployment of the repository pod.

- `yuuvis.services.archive.volumes`
  - Define volumes to be used (secrets or pvc or ...) 
- `yuuvis.services.archive.volumeMounts`
  - Define mountpoint(s) inside the pod and which `volume` to use

Example: Useful to mount external NetApp storage solution using PVCs