### PR TITLE
Improve Elastcsearch Memory Settings

### DIFF
--- a/infrastructure/templates/elasticsearch-data.yaml
+++ b/infrastructure/templates/elasticsearch-data.yaml
@@ -66,7 +66,12 @@ spec:
           protocol: TCP
         env:
         - name: "ES_JAVA_OPTS"
-          value: {{.Values.elasticsearch.highAvailability.data.memory}}  
+          value: {{.Values.elasticsearch.highAvailability.data.memory}}
+        {{- if .Values.elasticsearch.highAvailability.data.requests.memory }}
+        resources:
+          requests:
+            memory: {{.Values.elasticsearch.highAvailability.data.requests.memory}}
+        {{- end }}
         volumeMounts:
         - name: es-data
           mountPath: /usr/share/elasticsearch/data

--- a/infrastructure/templates/elasticsearch-data.yaml
+++ b/infrastructure/templates/elasticsearch-data.yaml
@@ -20,7 +20,7 @@ spec:
         name: elasticsearch
         app: {{.Values.yuuvis.labels.app}}
     spec:
-      {{- if or .Values.elasticsearch.highAvailability.highAvailability.data.nodeAffinity .Values.elasticsearch.highAvailability.data.podAffinity .Values.elasticsearch.highAvailability.data.podAntiAffinity }}
+      {{- if or .Values.elasticsearch.highAvailability.data.nodeAffinity .Values.elasticsearch.highAvailability.data.podAffinity .Values.elasticsearch.highAvailability.data.podAntiAffinity }}
       affinity:
         {{- with .Values.elasticsearch.highAvailability.data.nodeAffinity }}
         nodeAffinity: {{- toYaml . | nindent 10 }}

--- a/infrastructure/templates/elasticsearch-master.yaml
+++ b/infrastructure/templates/elasticsearch-master.yaml
@@ -66,7 +66,12 @@ spec:
           protocol: TCP
         env:
         - name: "ES_JAVA_OPTS"
-          value: {{.Values.elasticsearch.highAvailability.master.memory}}  
+          value: {{.Values.elasticsearch.highAvailability.master.memory}}
+        {{- if .Values.elasticsearch.highAvailability.master.requests.memory }}
+        resources:
+          requests:
+            memory: {{.Values.elasticsearch.highAvailability.master.requests.memory}}
+        {{- end }}
         volumeMounts:
         - name: es-data
           mountPath: /usr/share/elasticsearch/data

--- a/infrastructure/templates/elasticsearch.yaml
+++ b/infrastructure/templates/elasticsearch.yaml
@@ -66,6 +66,11 @@ spec:
         env:
         - name: "ES_JAVA_OPTS"
           value: {{.Values.elasticsearch.memory}}
+        {{- if .Values.elasticsearch.requests.memory }}
+        resources:
+          requests:
+            memory: {{.Values.elasticsearch.requests.memory}}
+        {{- end }}
         volumeMounts:
         - name: es-data
           mountPath: /usr/share/elasticsearch/data

--- a/infrastructure/values.yaml
+++ b/infrastructure/values.yaml
@@ -65,6 +65,8 @@ elasticsearch:
   nodes: 1
   initial_master_nodes: elasticsearch-0  
   memory: -Xms1024m -Xmx1024m
+  requests:
+    memory: 2Gi # always double of JVM memory setting
   pdb:    
     # pdb requires instances > 1 and minAvailable < instances,
     # otherwise draining nodes will deadlock!
@@ -85,6 +87,8 @@ elasticsearch:
       nodes: 2
       storage: 200Gi
       memory: -Xms4096m -Xmx4096m
+      requests:
+        memory: 8Gi # always double of JVM memory setting
       pdb:    
         # pdb requires instances > 1 and minAvailable < instances,
         # otherwise draining nodes will deadlock!
@@ -102,6 +106,8 @@ elasticsearch:
       nodes: 3
       storage: 50Gi
       memory: -Xms1024m -Xmx1024m
+      requests:
+        memory: 2Gi # always double of JVM memory setting
       initial_master_nodes: elasticsearch-master-0, elasticsearch-master-1, elasticsearch-master-2
       pdb:    
         # pdb requires instances > 1 and minAvailable < instances,


### PR DESCRIPTION
- Set Memory Requests for Pods running Elasticsearch
  - Memory Request is intentionally set to 200% of the JVM Heap Setting. Recommended by Elastic.co
  - https://www.elastic.co/guide/en/elasticsearch/reference/current/advanced-configuration.html#set-jvm-heap-size
- Fixed helm value path to nodeAffinity setting in elasticsearch-data 