### PR TITLE
SecurityContext for InitContainers

### DIFF
--- a/client/templates/api-web.yaml
+++ b/client/templates/api-web.yaml
@@ -35,6 +35,9 @@ spec:
       - name: init-api-web
         image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.initContainer.image}}:{{.Values.initContainer.tag}}"
         command: ["sh", "-c", "{{.Values.initContainer.command}}"]
+        {{- if .Values.initContainer.securityContext }}
+        securityContext:
+        {{- toYaml .Values.initContainer.securityContext | nindent 10 }}
         imagePullPolicy: IfNotPresent
       containers:
       - env:

--- a/client/templates/sothook.yaml
+++ b/client/templates/sothook.yaml
@@ -34,6 +34,9 @@ spec:
       - name: init-sothook
         image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.initContainer.image}}:{{.Values.initContainer.tag}}"
         command: ["sh", "-c", "{{.Values.initContainer.command}}"]
+        {{- if .Values.initContainer.securityContext }}
+        securityContext:
+        {{- toYaml .Values.initContainer.securityContext | nindent 10 }}
         imagePullPolicy: IfNotPresent
       containers:
       - name: sothook

--- a/client/templates/tenant-management.yaml
+++ b/client/templates/tenant-management.yaml
@@ -34,6 +34,9 @@ spec:
       - name: init-api-tm
         image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.initContainer.image}}:{{.Values.initContainer.tag}}"
         command: ["sh", "-c", "{{.Values.initContainer.command}}"]
+        {{- if .Values.initContainer.securityContext }}
+        securityContext:
+        {{- toYaml .Values.initContainer.securityContext | nindent 10 }}
         imagePullPolicy: IfNotPresent
       containers:
       - env:

--- a/client/templates/userservice.yaml
+++ b/client/templates/userservice.yaml
@@ -112,6 +112,9 @@ spec:
       - name: init-config
         image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.initContainer.image}}:{{.Values.initContainer.tag}}"
         command: ["sh", "-c", "{{.Values.initContainer.command}}"]
+        {{- if .Values.initContainer.securityContext }}
+        securityContext:
+        {{- toYaml .Values.initContainer.securityContext | nindent 10 }}
         imagePullPolicy: IfNotPresent
       restartPolicy: Always
       {{- with .Values.yuuvis.client.userservice.nodeSelector }}

--- a/rendition/templates/rendition-repository.yaml
+++ b/rendition/templates/rendition-repository.yaml
@@ -76,6 +76,9 @@ spec:
         image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.initContainer.image}}:{{.Values.initContainer.tag}}"
         imagePullPolicy: IfNotPresent
         command: ["sh", "-c", "{{.Values.initContainer.command}}"]
+        {{- if .Values.initContainer.securityContext }}
+        securityContext:
+        {{- toYaml .Values.initContainer.securityContext | nindent 10 }}
       {{- with .Values.yuuvis.renditionrepository.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/rendition/templates/renditionservice.yaml
+++ b/rendition/templates/renditionservice.yaml
@@ -61,6 +61,9 @@ spec:
         image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.initContainer.image}}:{{.Values.initContainer.tag}}"
         imagePullPolicy: IfNotPresent
         command: ["sh", "-c", "{{.Values.initContainer.command}}"]
+        {{- if .Values.initContainer.securityContext }}
+        securityContext:
+        {{- toYaml .Values.initContainer.securityContext | nindent 10 }}
       {{- with .Values.yuuvis.renditionservice.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/rendition/templates/renditiontextworker.yaml
+++ b/rendition/templates/renditiontextworker.yaml
@@ -142,6 +142,9 @@ spec:
         image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.initContainer.image}}:{{.Values.initContainer.tag}}"
         imagePullPolicy: IfNotPresent
         command: ["sh", "-c", "{{.Values.initContainer.command}}"]
+        {{- if .Values.initContainer.securityContext }}
+        securityContext:
+        {{- toYaml .Values.initContainer.securityContext | nindent 10 }}
       {{- with .Values.yuuvis.renditiontextworker.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/repositorymanager/templates/repositorymanager-mq.yaml
+++ b/repositorymanager/templates/repositorymanager-mq.yaml
@@ -43,6 +43,9 @@ spec:
         image: busybox
         imagePullPolicy: IfNotPresent
         command: ["sh", "-c", "{{.Values.initContainer.command}}"]
+        {{- if .Values.initContainer.securityContext }}
+        securityContext:
+        {{- toYaml .Values.initContainer.securityContext | nindent 10 }}
       {{- with .Values.yuuvis.repositorymanager.mq.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/repositorymanager/templates/repositorymanager.yaml
+++ b/repositorymanager/templates/repositorymanager.yaml
@@ -72,6 +72,9 @@ spec:
         image: busybox
         imagePullPolicy: IfNotPresent
         command: ["sh", "-c", "{{.Values.initContainer.command}}"]
+        {{- if .Values.initContainer.securityContext }}
+        securityContext:
+        {{- toYaml .Values.initContainer.securityContext | nindent 10 }}
       {{- with .Values.yuuvis.repositorymanager.core.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/repositorymanageral/templates/repositorymanager-al.yaml
+++ b/repositorymanageral/templates/repositorymanager-al.yaml
@@ -72,4 +72,7 @@ spec:
           image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.yuuvis.repositorymanageral.initContainerImage}}"
           imagePullPolicy: IfNotPresent
           command: ["sh", "-c", "{{.Values.initContainer.command}}"]
+        {{- if .Values.initContainer.securityContext }}
+        securityContext:
+        {{- toYaml .Values.initContainer.securityContext | nindent 10 }}
 

--- a/repositorymanagercmis/templates/repositorymanager-cmis.yaml
+++ b/repositorymanagercmis/templates/repositorymanager-cmis.yaml
@@ -48,4 +48,7 @@ spec:
           image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.yuuvis.repositorymanagercmis.initContainerImage}}"
           imagePullPolicy: IfNotPresent
           command: ["sh", "-c", "{{.Values.initContainer.command}}"]
+        {{- if .Values.initContainer.securityContext }}
+        securityContext:
+        {{- toYaml .Values.initContainer.securityContext | nindent 10 }}
 

--- a/repositorymanagerilm/templates/repositorymanager-ilm.yaml
+++ b/repositorymanagerilm/templates/repositorymanager-ilm.yaml
@@ -48,4 +48,7 @@ spec:
           image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.yuuvis.repositorymanagerilm.initContainerImage}}"
           imagePullPolicy: IfNotPresent
           command: ["sh", "-c", "{{.Values.initContainer.command}}"]
+        {{- if .Values.initContainer.securityContext }}
+        securityContext:
+        {{- toYaml .Values.initContainer.securityContext | nindent 10 }}
 

--- a/yuuvis/templates/api.yaml
+++ b/yuuvis/templates/api.yaml
@@ -32,6 +32,9 @@ spec:
         image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.initContainer.image}}:{{.Values.initContainer.tag}}"
         imagePullPolicy: {{.Values.initContainer.imagePullPolicy}}
         command: ["sh", "-c", "{{.Values.initContainer.command}}"]
+        {{- if .Values.initContainer.securityContext }}
+        securityContext:
+        {{- toYaml .Values.initContainer.securityContext | nindent 10 }}
       containers:
       - name: api
         image: "{{.Values.yuuvis.image.dockerRegistry}}/{{ .Values.yuuvis.services.api.dockerImage }}:{{ .Values.yuuvis.services.api.tag }}"

--- a/yuuvis/templates/archiveservice.yaml
+++ b/yuuvis/templates/archiveservice.yaml
@@ -33,6 +33,9 @@ spec:
         image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.initContainer.image}}:{{.Values.initContainer.tag}}"
         imagePullPolicy: {{.Values.initContainer.imagePullPolicy}}
         command: ["sh", "-c", "{{.Values.initContainer.command}}"]
+        {{- if .Values.initContainer.securityContext }}
+        securityContext:
+        {{- toYaml .Values.initContainer.securityContext | nindent 10 }}
       containers:
       - name: archive
         image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.yuuvis.services.archive.dockerImage}}:{{ .Values.yuuvis.services.archive.tag }}"

--- a/yuuvis/templates/authentication.yaml
+++ b/yuuvis/templates/authentication.yaml
@@ -32,6 +32,9 @@ spec:
         image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.initContainer.image}}:{{.Values.initContainer.tag}}"
         imagePullPolicy: {{.Values.initContainer.imagePullPolicy}}
         command: ["sh", "-c", "{{.Values.initContainer.command}}"]
+        {{- if .Values.initContainer.securityContext }}
+        securityContext:
+        {{- toYaml .Values.initContainer.securityContext | nindent 10 }}
       containers:
       - name: authentication
         image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.yuuvis.services.authentication.dockerImage}}:{{ .Values.yuuvis.services.authentication.tag }}"

--- a/yuuvis/templates/commander.yaml
+++ b/yuuvis/templates/commander.yaml
@@ -32,6 +32,9 @@ spec:
         image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.initContainer.image}}:{{.Values.initContainer.tag}}"
         imagePullPolicy: {{.Values.initContainer.imagePullPolicy}}
         command: ["sh", "-c", "{{.Values.initContainer.command}}"]
+        {{- if .Values.initContainer.securityContext }}
+        securityContext:
+        {{- toYaml .Values.initContainer.securityContext | nindent 10 }}
       containers:
       - name: commander
         image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.yuuvis.services.commander.dockerImage}}:{{ .Values.yuuvis.services.commander.tag }}"

--- a/yuuvis/templates/index.yaml
+++ b/yuuvis/templates/index.yaml
@@ -32,6 +32,9 @@ spec:
         image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.initContainer.image}}:{{.Values.initContainer.tag}}"
         imagePullPolicy: {{.Values.initContainer.imagePullPolicy}}
         command: ["sh", "-c", "{{.Values.initContainer.command}}"]
+        {{- if .Values.initContainer.securityContext }}
+        securityContext:
+        {{- toYaml .Values.initContainer.securityContext | nindent 10 }}
       containers:
       - name: index
         image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.yuuvis.services.index.dockerImage}}:{{ .Values.yuuvis.services.index.tag }}"

--- a/yuuvis/templates/registry.yaml
+++ b/yuuvis/templates/registry.yaml
@@ -32,6 +32,9 @@ spec:
         image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.initContainer.image}}:{{.Values.initContainer.tag}}"
         imagePullPolicy: {{.Values.initContainer.imagePullPolicy}}
         command: ["sh", "-c", "{{.Values.initContainer.command}}"]
+        {{- if .Values.initContainer.securityContext }}
+        securityContext:
+        {{- toYaml .Values.initContainer.securityContext | nindent 10 }}
       containers:
       - name: registry
         image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.yuuvis.services.registry.dockerImage}}:{{ .Values.yuuvis.services.registry.tag }}"

--- a/yuuvis/templates/repository.yaml
+++ b/yuuvis/templates/repository.yaml
@@ -32,6 +32,9 @@ spec:
         image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.initContainer.image}}:{{.Values.initContainer.tag}}"
         imagePullPolicy: {{.Values.initContainer.imagePullPolicy}}
         command: ["sh", "-c", "{{.Values.initContainer.command}}"]
+        {{- if .Values.initContainer.securityContext }}
+        securityContext:
+        {{- toYaml .Values.initContainer.securityContext | nindent 10 }}
       containers:
       - name: repository
         image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.yuuvis.services.repository.dockerImage}}:{{ .Values.yuuvis.services.repository.tag }}"

--- a/yuuvis/templates/search.yaml
+++ b/yuuvis/templates/search.yaml
@@ -32,6 +32,9 @@ spec:
         image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.initContainer.image}}:{{.Values.initContainer.tag}}"
         imagePullPolicy: {{.Values.initContainer.imagePullPolicy}}
         command: ["sh", "-c", "{{.Values.initContainer.command}}"]
+        {{- if .Values.initContainer.securityContext }}
+        securityContext:
+        {{- toYaml .Values.initContainer.securityContext | nindent 10 }}
       containers:
       - name: search
         image: "{{.Values.yuuvis.image.dockerRegistry}}/{{.Values.yuuvis.services.search.dockerImage}}:{{ .Values.yuuvis.services.search.tag }}"


### PR DESCRIPTION
Sometimes, `initContainers `need their own SecurityContext Settings.

e.g. Using NetworkPolicies or Istio, where InitContainers are handled a bit different, and one needs to define "`runAsUser`" or something else for the `initContainer`, so that it is able to connect for checks to the internal system